### PR TITLE
Updated info.plist specifications and name of macOS bundle

### DIFF
--- a/VICREO_Listener_OSX.spec
+++ b/VICREO_Listener_OSX.spec
@@ -23,7 +23,7 @@ exe = EXE(pyz,
           a.zipfiles,
           a.datas,
           [],
-          name='VICREO_Listener_OSX',
+          name='VICREO Listener',
           debug=False,
           bootloader_ignore_signals=False,
           strip=False,
@@ -31,6 +31,13 @@ exe = EXE(pyz,
           runtime_tmpdir=None,
           console=False)
 app = BUNDLE(exe,
-             name='VICREO_Listener_OSX.app',
+             name='VICREO Listener.app',
              icon='/Users/jeffreydavidsz/VICREO-Listener/icon.icns',
-             bundle_identifier=None)
+             bundle_identifier=None,
+             info_plist={
+                'LSUIElement': 'True',
+                'NSHighResolutionCapable': 'True',
+                'CFBundleShortVersionString': '1.3.2',
+                'NSHumanReadableCopyright': 'Copyright © 2019, Jeffrey Davidsz. All rights reserved.'
+            },
+        )


### PR DESCRIPTION
**name='VICREO Listener', name='VICREO Listener.app',**
-Cleaned up app name to remove underscores and "OSX." This should prevent macOS from truncating the name with a ... in certain places.

**'LSUIElement': 'True',** 
-Prevents the app icon from being displayed in the dock. This fixes an issue where, on launch, the app would appear in the doc and then disappear immediately.

**'NSHighResolutionCapable': 'True',**
-Fixes text pixelation issues on Retina display Macs

**'CFBundleShortVersionString': '1.3.2',**
-Adds version number to "Get Info" data of the bundle. Helpful for keeping track of installed version.

**'NSHumanReadableCopyright': 'Copyright © 2019, Jeffrey Davidsz. All rights reserved.'**
-Adds copyright information to the "Get Info" data of the bundle