### PR TITLE
Hide dock icon on OSX

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -12,6 +12,9 @@ const config = {
       "entitlements-inherit": "./static/entitlements.plist",
       "identity": "Developer ID Application: VICREO BV (XS47984U9A)"
     },
+    "extendInfo": {
+      "LSUIElement": 1
+    },
 		"icon": "./src/img/icon"
   },
   makers: [


### PR DESCRIPTION
I just downloaded v2.0.7 and noticed that the dock icon is visible while the application is running, whereas before the icon was only visible in the menubar. 

This PR adds the `LSUIElement` key to tell OSX that is should not display the dock icon.