### PR TITLE
Save custom port number, time in logs tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ typings/
 
 # Electron-Forge
 out/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "make": "electron-forge make",
     "release": "electron-forge publish",
     "devstart": "electromon ./src/index.js",
-		"rebuild": "electron-rebuild -f -w ./src/index.js",
-		"lint": "echo \"No linting configured\""
+    "rebuild": "electron-rebuild -f -w ./src/index.js",
+    "lint": "echo \"No linting configured\""
   },
   "keywords": [
     "keyboard emulator",
@@ -29,6 +29,7 @@
     "dotenv": "^8.2.0",
     "electron-notarize": "^1.0.0",
     "electron-squirrel-startup": "^1.0.0",
+    "electron-store": "^6.0.0",
     "robotjs": "^0.6.0",
     "run-applescript": "^4.0.0"
   },

--- a/src/screen.html
+++ b/src/screen.html
@@ -118,6 +118,11 @@
 			cursor: pointer;
 			border-color: #e2007a;
 		}
+
+		textarea {
+			resize: none; 
+			padding: 5px;
+		}
 	</style>
 </head>
 <h1><label id="version">Welcome!</label></h1>
@@ -140,7 +145,7 @@
 
 	ipcRenderer.on('log', (event, arg) => {
 		let today = new Date();
-		let time = today.getHours() + ":" + today.getMinutes() + ":" + today.getSeconds() + " ";
+		let time = today.getHours() + ":" + String(today.getMinutes()).padStart(2, "0") + ":" + String(today.getSeconds()).padStart(2, "0") + " ";
 		document.getElementById('logs').innerHTML = time + arg.concat('\n', document.getElementById('logs').innerHTML)
 		// document.getElementById('logs').innerHTML += '\n' + arg;
 	})

--- a/src/screen.html
+++ b/src/screen.html
@@ -129,7 +129,7 @@
 <p>You can close this screen, and the app will remain open in the system tray (Windows) or the menu bar (macOS).</p>
 <p>The app will listen on port 10001 by default, but you can change that here:</p>
 <h3>Port number</h3>
-<input id="port" class="form-control text-input" value="10001">
+<input id="port" class="form-control text-input" value="">
 <input id="changeBtn" type="button" value="Change">
 <br>
 <p>Logs:</p>
@@ -142,6 +142,10 @@
 <script>
 
 	const { ipcRenderer } = require('electron')
+
+	ipcRenderer.on('initport', (event, arg) => {
+		document.getElementById('port').value = arg;
+	})
 
 	ipcRenderer.on('log', (event, arg) => {
 		let today = new Date();


### PR DESCRIPTION
–Stores the port number after it's changed by the user
–Recalls custom port on relaunch of app
–Populates port number into UI field based on stored value
–Makes all numbers in the log time 2-digit. Ex 10:09:50 (new) vs 10:9:50 (old)